### PR TITLE
Don't hard-code name in edit summary

### DIFF
--- a/position_statements.py
+++ b/position_statements.py
@@ -136,7 +136,7 @@ for statement in statements:
 for command in commands:
     summary = 'Edited with PositionStatements'
     if user_name:
-        summary += ' on behalf of [[User:{}]]'.format('Chris Mytton')
+        summary += ' on behalf of [[User:{}]]'.format(user_name)
 
     # Get the item we want to modify
     item = pywikibot.ItemPage(repo, command['item'])


### PR DESCRIPTION
As pointed out by @tmtmtmtm in https://github.com/everypolitician/position_statements/pull/9#pullrequestreview-64841430, we don't want to _always_ use my name in the edit summary. Oops! 😥 