### PR TITLE
Allow adding qualifiers / sources to an existing P39 snak

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,3 +6,4 @@ verify_ssl = true
 pywikibot = "*"
 
 [dev-packages]
+pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,22 +1,22 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8411293ed28b061199060cc2b602ee44bff957e974d1c8bf9a3d9a3073372b21"
+            "sha256": "a44b3ae480659ee8e994b5daf9a7a4fb9338404cb2b408ce188cf3da77e6f165"
         },
         "host-environment-markers": {
             "implementation_name": "cpython",
-            "implementation_version": "3.6.2",
+            "implementation_version": "3.5.2",
             "os_name": "posix",
             "platform_machine": "x86_64",
             "platform_python_implementation": "CPython",
-            "platform_release": "16.7.0",
-            "platform_system": "Darwin",
-            "platform_version": "Darwin Kernel Version 16.7.0: Thu Jun 15 17:36:27 PDT 2017; root:xnu-3789.70.16~2/RELEASE_X86_64",
-            "python_full_version": "3.6.2",
-            "python_version": "3.6",
-            "sys_platform": "darwin"
+            "platform_release": "4.4.0-96-generic",
+            "platform_system": "Linux",
+            "platform_version": "#119-Ubuntu SMP Tue Sep 12 14:59:54 UTC 2017",
+            "python_full_version": "3.5.2",
+            "python_version": "3.5",
+            "sys_platform": "linux"
         },
-        "pipfile-spec": 3,
+        "pipfile-spec": 6,
         "requires": {},
         "sources": [
             {
@@ -68,5 +68,20 @@
             "version": "==1.22"
         }
     },
-    "develop": {}
+    "develop": {
+        "py": {
+            "hashes": [
+                "sha256:2ccb79b01769d99115aa600d7eed99f524bf752bba8f041dc1c184853514655a",
+                "sha256:0f2d585d22050e90c7d293b6451c83db097df77871974d90efd5a30dc12fcde3"
+            ],
+            "version": "==1.4.34"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:b84f554f8ddc23add65c411bf112b2d88e2489fd45f753b1cae5936358bdf314",
+                "sha256:f46e49e0340a532764991c498244a60e3a37d7424a532b3ff1a6a7653f1a403a"
+            ],
+            "version": "==3.2.2"
+        }
+    }
 }

--- a/position_statements.py
+++ b/position_statements.py
@@ -13,7 +13,8 @@ time_re = re.compile(
     '^([+-]{0,1})(\d+)-(\d\d)-(\d\d)T(\d\d):(\d\d):(\d\d)Z\/{0,1}(\d*)$',
     re.IGNORECASE
 )
-
+uuid_re = r'(?P<uuid>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\Z'
+statement_re = re.compile(r'(wds:)?(?P<q>Q\d+)[-\$]' + uuid_re, re.I)
 
 def entity_type(value):
     if value.startswith('Q'):
@@ -52,6 +53,13 @@ def parse_value(value):
                 'time': re.sub(r'\/\d+$', '', value),
                 'precision': precision
             }
+        }
+
+    m = statement_re.match(value)
+    if m:
+        return {
+            'type': 'x-wikidata-statementid',
+            'value': m.group('q') + '$' + m.group('uuid')
         }
 
     sys.exit("Unrecognised value: {}".format(value))

--- a/position_statements.py
+++ b/position_statements.py
@@ -72,105 +72,106 @@ def expanded_datavalue(datavalue):
         time.precision = datavalue['value']['precision']
         return time
 
+if __name__ == '__main__':
 
-if len(sys.argv) == 1:
-    sys.exit("Usage: %s <filename> [<user_for_attribution>]" % sys.argv[0])
+    if len(sys.argv) == 1:
+        sys.exit("Usage: %s <filename> [<user_for_attribution>]" % sys.argv[0])
 
-p = Path(sys.argv[1])
+    p = Path(sys.argv[1])
 
-if not p.is_file():
-    sys.exit('"%s" is not a file' % sys.argv[1])
+    if not p.is_file():
+        sys.exit('"%s" is not a file' % sys.argv[1])
 
-try:
-    user_name = sys.argv[2]
-except IndexError:
-    user_name = None
-
-site = pywikibot.Site()
-repo = site.data_repository()
-
-with p.open() as f:
-    statements_string = f.read()
-
-statements = [s for s in statements_string.split("\n") if s.strip() != '']
-
-commands = []
-
-# Parse statements
-for statement in statements:
-    command = {}
-    parts = [s.strip() for s in statement.split("\t")]
-    command['item'] = parts[0]
-    command['property'] = parts[1]
-    command['datavalue'] = parse_value(parts[2])
-    qualifiers = parts[3:]
-    qualifier_pairs = list(zip(qualifiers[::2], qualifiers[1::2]))
-    command['qualifiers'] = []
-    command['sources'] = []
-    for p, v in qualifier_pairs:
-        what = 'sources' if p.startswith('S') else 'qualifiers'
-        prop = re.sub(r'^S', 'P', p)
-        q = {'property': prop, 'datavalue': parse_value(v)}
-        command[what].append(q)
-
-    # Validate statements
-    m = item_re.match(command['item'])
-    if m is None:
-        sys.exit("Invalid item ID format: {}".format(command['item']))
-
-    if command['property'] != 'P39':
-        sys.exit("Only P39 statements are supported currently. (Got {})".format(command['property']))
-
-    if len(qualifiers) % 2 != 0:
-        sys.exit("Odd number of qualifier/source pairs detected: {}".format(qualifiers))
-
-    for qualifier in command['qualifiers']:
-        m = property_re.match(qualifier['property'])
-        if m is None:
-            sys.exit("Invalid qualifier property: {}".format(qualifier['property']))
-
-    for source in command['sources']:
-        m = property_re.match(source['property'])
-        if m is None:
-            sys.exit("Invalid source property: {}".format(source['property']))
-
-    # Validations passed, add to list of commands.
-    commands.append(command)
-
-for command in commands:
-    print(command)
-    summary = 'Edited with PositionStatements'
-    if user_name:
-        summary += ' on behalf of [[User:{}]]'.format(user_name)
-
-    # Get the item we want to modify
-    item = pywikibot.ItemPage(repo, command['item'])
     try:
-        item.get()
-    except pywikibot.IsRedirectPage:
-        item = item.getRedirectTarget()
+        user_name = sys.argv[2]
+    except IndexError:
+        user_name = None
 
-    # Get the claim we're dealing with
-    claim = pywikibot.Claim(site, command['property'])
+    site = pywikibot.Site()
+    repo = site.data_repository()
 
-    # Create a new P39 statement pointing to Q123
-    claim.setTarget(expanded_datavalue(command['datavalue']))
+    with p.open() as f:
+        statements_string = f.read()
 
-    # Add the claim to the item.
-    item.addClaim(claim, summary=summary)
+    statements = [s for s in statements_string.split("\n") if s.strip() != '']
 
-    for qualifier in command['qualifiers']:
-        qualifier_claim = pywikibot.Claim(
-            site, qualifier['property'], isQualifier=True
-        )
-        qualifier_claim.setTarget(expanded_datavalue(qualifier['datavalue']))
-        claim.addQualifier(qualifier_claim, summary=summary)
+    commands = []
 
-    sources = []
-    for source in command['sources']:
-        source_claim = pywikibot.Claim(
-            site, source['property'], isReference=True
-        )
-        source_claim.setTarget(expanded_datavalue(source['datavalue']))
-        sources.append(source_claim)
-    claim.addSources(sources, summary=summary)
+    # Parse statements
+    for statement in statements:
+        command = {}
+        parts = [s.strip() for s in statement.split("\t")]
+        command['item'] = parts[0]
+        command['property'] = parts[1]
+        command['datavalue'] = parse_value(parts[2])
+        qualifiers = parts[3:]
+        qualifier_pairs = list(zip(qualifiers[::2], qualifiers[1::2]))
+        command['qualifiers'] = []
+        command['sources'] = []
+        for p, v in qualifier_pairs:
+            what = 'sources' if p.startswith('S') else 'qualifiers'
+            prop = re.sub(r'^S', 'P', p)
+            q = {'property': prop, 'datavalue': parse_value(v)}
+            command[what].append(q)
+
+        # Validate statements
+        m = item_re.match(command['item'])
+        if m is None:
+            sys.exit("Invalid item ID format: {}".format(command['item']))
+
+        if command['property'] != 'P39':
+            sys.exit("Only P39 statements are supported currently. (Got {})".format(command['property']))
+
+        if len(qualifiers) % 2 != 0:
+            sys.exit("Odd number of qualifier/source pairs detected: {}".format(qualifiers))
+
+        for qualifier in command['qualifiers']:
+            m = property_re.match(qualifier['property'])
+            if m is None:
+                sys.exit("Invalid qualifier property: {}".format(qualifier['property']))
+
+        for source in command['sources']:
+            m = property_re.match(source['property'])
+            if m is None:
+                sys.exit("Invalid source property: {}".format(source['property']))
+
+        # Validations passed, add to list of commands.
+        commands.append(command)
+
+    for command in commands:
+        print(command)
+        summary = 'Edited with PositionStatements'
+        if user_name:
+            summary += ' on behalf of [[User:{}]]'.format(user_name)
+
+        # Get the item we want to modify
+        item = pywikibot.ItemPage(repo, command['item'])
+        try:
+            item.get()
+        except pywikibot.IsRedirectPage:
+            item = item.getRedirectTarget()
+
+        # Get the claim we're dealing with
+        claim = pywikibot.Claim(site, command['property'])
+
+        # Create a new P39 statement pointing to Q123
+        claim.setTarget(expanded_datavalue(command['datavalue']))
+
+        # Add the claim to the item.
+        item.addClaim(claim, summary=summary)
+
+        for qualifier in command['qualifiers']:
+            qualifier_claim = pywikibot.Claim(
+                site, qualifier['property'], isQualifier=True
+            )
+            qualifier_claim.setTarget(expanded_datavalue(qualifier['datavalue']))
+            claim.addQualifier(qualifier_claim, summary=summary)
+
+        sources = []
+        for source in command['sources']:
+            source_claim = pywikibot.Claim(
+                site, source['property'], isReference=True
+            )
+            source_claim.setTarget(expanded_datavalue(source['datavalue']))
+            sources.append(source_claim)
+        claim.addSources(sources, summary=summary)

--- a/position_statements.py
+++ b/position_statements.py
@@ -1,3 +1,4 @@
+import json
 import pywikibot
 import sys
 import re
@@ -164,7 +165,7 @@ if __name__ == '__main__':
         commands.append(command)
 
     for command in commands:
-        print(command)
+        print(json.dumps(command, indent=4, sort_keys=True))
         summary = 'Edited with PositionStatements'
         if user_name:
             summary += ' on behalf of [[User:{}]]'.format(user_name)

--- a/position_statements.py
+++ b/position_statements.py
@@ -206,4 +206,5 @@ if __name__ == '__main__':
             )
             source_claim.setTarget(expanded_datavalue(source['datavalue']))
             sources.append(source_claim)
-        claim.addSources(sources, summary=summary)
+        if sources:
+            claim.addSources(sources, summary=summary)

--- a/test_parse_value.py
+++ b/test_parse_value.py
@@ -1,0 +1,24 @@
+from position_statements import parse_value
+
+def test_parse_value_item_id():
+    assert parse_value('Q42') == {
+        'type': 'wikibase-entityid',
+        'value': {
+            'entity-type': 'item', 'id': 'Q42'
+        }
+    }
+
+def test_parse_value_string():
+    assert parse_value('" hello, i\'m a "string"  \"') == {
+        'type': 'string',
+        'value': 'hello, i\'m a "string"',
+    }
+
+def test_parse_value_time():
+    assert parse_value('+2000-01-20T00:04:35Z/11') == {
+        'type': 'time',
+        'value': {
+            'time': '+2000-01-20T00:04:35Z',
+            'precision': 11
+        }
+    }

--- a/test_parse_value.py
+++ b/test_parse_value.py
@@ -1,4 +1,8 @@
-from position_statements import parse_value
+from unittest.mock import Mock
+
+import pytest
+
+from position_statements import get_existing_claim, parse_value
 
 def test_parse_value_item_id():
     assert parse_value('Q42') == {
@@ -40,3 +44,36 @@ def test_parse_value_statement_wds_uuid():
         'type': 'x-wikidata-statementid',
         'value': 'Q42$DD45AFB0-7249-4690-AAE3-86C9FF996CE2',
     }
+
+def test_get_existing_claim_unknown_property():
+    mock_item = Mock(claims={})
+    with pytest.raises(Exception) as excinfo:
+        get_existing_claim(
+            mock_item,
+            'P123456',
+            'Q42$DD45AFB0-7249-4690-AAE3-86C9FF996CE2'
+        )
+    assert 'No property P123456 found in claims of' in str(excinfo.value)
+
+def test_get_claim_missing():
+    mock_item = Mock(claims={'P123456': []})
+    mock_item.__str__ = Mock()
+    mock_item.__str__.return_value = '<Item: Some item or other>'
+    with pytest.raises(Exception) as excinfo:
+        get_existing_claim(
+            mock_item,
+            'P123456',
+            'Q42$DD45AFB0-7249-4690-AAE3-86C9FF996CE2'
+        )
+    assert 'The snak Q42$DD45AFB0-7249-4690-AAE3-86C9FF996CE2 was ' \
+        'not found for any claim on \'<Item: Some item or other>\' ' \
+        'with property P123456' in str(excinfo.value)
+
+def test_get_claim_found():
+    mock_claim = Mock(snak='Q42$DD45AFB0-7249-4690-AAE3-86C9FF996CE2')
+    mock_item = Mock(claims={'P123456': [mock_claim]})
+    assert get_existing_claim(
+        mock_item,
+        'P123456',
+        'Q42$DD45AFB0-7249-4690-AAE3-86C9FF996CE2'
+    ) is mock_claim

--- a/test_parse_value.py
+++ b/test_parse_value.py
@@ -22,3 +22,21 @@ def test_parse_value_time():
             'precision': 11
         }
     }
+
+def test_parse_value_statement_raw_uuid():
+    assert parse_value('Q42-DD45AFB0-7249-4690-AAE3-86C9FF996CE2') == {
+        'type': 'x-wikidata-statementid',
+        'value': 'Q42$DD45AFB0-7249-4690-AAE3-86C9FF996CE2',
+    }
+
+def test_parse_value_statement_api_uuid():
+    assert parse_value('Q42$DD45AFB0-7249-4690-AAE3-86C9FF996CE2') == {
+        'type': 'x-wikidata-statementid',
+        'value': 'Q42$DD45AFB0-7249-4690-AAE3-86C9FF996CE2',
+     }
+
+def test_parse_value_statement_wds_uuid():
+    assert parse_value('wds:Q42-DD45AFB0-7249-4690-AAE3-86C9FF996CE2') == {
+        'type': 'x-wikidata-statementid',
+        'value': 'Q42$DD45AFB0-7249-4690-AAE3-86C9FF996CE2',
+    }


### PR DESCRIPTION
In previous use of this tool, the claim created was specified by the
first three fields:

  SubjectItem   P39     ObjectItem

This change allows you to use a snak ID / a statement UUID in place of
ObjectItem, so that you can modify a precisely specified existing claim
instead, in order to add qualifiers or sources to it.
